### PR TITLE
fix the "out of index" exception:

### DIFF
--- a/src/menu.py
+++ b/src/menu.py
@@ -125,7 +125,7 @@ class Menu:
 
             # 前进
             elif key == ord('l') or key == 10:
-                if self.datatype == 'songs' or self.datatype == 'djchannels' or self.datatype == 'help':
+                if self.datatype == 'songs' or self.datatype == 'djchannels' or self.datatype == 'help' or len(self.datalist) <= 0:
                     continue
                 self.ui.build_loading()
                 self.dispatch_enter(idx)


### PR DESCRIPTION
```
when search for "artists" or "album" and nothing returned, press l or enter makes it quit abnormally.
```
